### PR TITLE
Accept empty collections

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var ENTER_KEY = 13;
 
 module.exports = function(els) {
   if (!els) return
-  if (!els.length) return enterMeansSubmit(els)
+  if (els.length === undefined) return enterMeansSubmit(els)
 
   for (var i = 0; i < els.length; ++i) {
     enterMeansSubmit(els[i]);


### PR DESCRIPTION
If the `els` is empty, the error is produced from treating it as a single element.

``` js
TypeError: el.getElementsByTagName is not a function
```
